### PR TITLE
 Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Depends:
 Imports: 
     methods,
     Rcpp (>= 0.12.0),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.0.0),
     Formula (>= 1.2-1),
     stats (>= 3.4.0),
@@ -39,8 +39,8 @@ LinkingTo:
     BH (>= 1.66.0),
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make
 RoxygenNote: 7.1.1
 BugReports: https://github.com/stephenSRMMartin/MIRES/issues

--- a/inst/stan/functions/marg.stan
+++ b/inst/stan/functions/marg.stan
@@ -7,7 +7,7 @@
       E(Y_ik | k) = nu_k + E(eta_ik | k) * Lambda_k
       Cov(Y_ik | k) = Lambda'_k V(eta_ik | k) Lambda_k + diag(exp(2 * resid_log_k))
     */
-matrix[] marg_cov_uni(
+array[] matrix marg_cov_uni(
 		      row_vector lambda,
                       row_vector resid_log,
                       matrix lambda_random,
@@ -16,7 +16,7 @@ matrix[] marg_cov_uni(
 		 ) {
   int J = cols(lambda);
   int K = rows(lambda_random);
-  matrix[J,J] cov_out[K];
+  array[K] matrix[J,J] cov_out;
   matrix[K, J] lambda_k = (rep_matrix(lambda, K) + lambda_random) .* rep_matrix(eta_sd, J);
   matrix[K, J] resid_k = exp(2 * (rep_matrix(resid_log, K) + resid_random));
   for(k in 1:K) {
@@ -50,12 +50,12 @@ matrix marg_expect_uni(
   return(exp_out);
 }
 
-int[,] sort_data_by_group_indices(int[] group) {
+array[,] int sort_data_by_group_indices(array[] int group) {
   int K = max(group);
   int N = num_elements(group);
-  int group_sorted[N] = sort_asc(group);
-  int out[K,2];
-  int n_k[K] = rep_array(0, K);
+  array[N] int group_sorted = sort_asc(group);
+  array[K,2] int out;
+  array[K] int n_k = rep_array(0, K);
   int index = 1;
   for(n in 1:N) { // Count observations of each group.
     n_k[group[n]] += 1;
@@ -68,13 +68,13 @@ int[,] sort_data_by_group_indices(int[] group) {
   return(out);
 }
 
-row_vector[] sort_data_by_group(matrix x, int[] group) {
+array[] row_vector sort_data_by_group(matrix x, array[] int group) {
   int K = max(group);
   int N = rows(x);
   int J = cols(x);
-  row_vector[J] out[N];
+  array[N] row_vector[J] out;
   /* matrix[N, J] out; */
-  int group_ordered[N] = sort_indices_asc(group);
+  array[N] int group_ordered = sort_indices_asc(group);
 
   /* int index = 1; */
   /* for(k in 1:K) { */

--- a/inst/stan/functions/md.stan
+++ b/inst/stan/functions/md.stan
@@ -5,11 +5,11 @@
     Nus and sigmas constitute 2*J indices, but not loadings.
     Currently, loadings are organized in (row-major) order of lambdaEst.
    */
-  int[] gen_item_indices_md(int J, int F, int[] J_f, int[,] F_ind) {
+  array[] int gen_item_indices_md(int J, int F, array[] int J_f, array[,] int F_ind) {
     int total_lambda = sum(J_f);
-    int resid_nu[2*J];
-    int lambda[total_lambda];
-    int lambda_resid_nu[total_lambda + 2*J];
+    array[2*J] int resid_nu;
+    array[total_lambda] int lambda;
+    array[total_lambda + 2*J] int lambda_resid_nu;
 
     // Resid and nu
     int base = 0;
@@ -33,12 +33,12 @@
     return(lambda_resid_nu);
   }
 
-  int[] gen_param_indices_md(int J, int[] J_f) {
-    int resid[J] = rep_array(2, J);
-    int nu[J] = rep_array(3, J);
+  array[] int gen_param_indices_md(int J, array[] int J_f) {
+    array[J] int resid = rep_array(2, J);
+    array[J] int nu = rep_array(3, J);
     int lambda_total = sum(J_f);
-    int lambda[lambda_total] = rep_array(1, lambda_total);
-    int lambda_resid_nu[lambda_total + 2*J] = append_array(lambda, append_array(resid, nu));
+    array[lambda_total] int lambda = rep_array(1, lambda_total);
+    array[lambda_total + 2*J] int lambda_resid_nu = append_array(lambda, append_array(resid, nu));
 
     return(lambda_resid_nu);
   }
@@ -50,8 +50,8 @@
     [8, 12] // Resid locations are vec[8:12]
     [13, 17] // Nu locations are vec[13:27]
    */
-  int[,] gen_lamResNu_bounds(int J, int[] J_f){
-    int out[3, 2];
+  array[,] int gen_lamResNu_bounds(int J, array[] int J_f){
+    array[3, 2] int out;
     int lambda_total = sum(J_f);
     out[1] = {1, lambda_total};
     out[2] = {lambda_total + 1, lambda_total + J};
@@ -60,8 +60,8 @@
     return(out);
   }
 
-  matrix lambda_mat(int[] J_f, int[,] F_ind, row_vector lambdaEst) {
-    int F_J[2] = dims(F_ind);  
+  matrix lambda_mat(array[] int J_f, array[,] int F_ind, row_vector lambdaEst) {
+    array[2] int F_J = dims(F_ind);  
     int F = F_J[1];
     int J = F_J[2];
     int tot = sum(J_f);

--- a/inst/stan/functions/ud.stan
+++ b/inst/stan/functions/ud.stan
@@ -4,8 +4,8 @@
     1 = indicator 1
     J = indicator J
    */ 
-  int[] gen_item_indices(int J) {
-    int hm_item_index[3*J];
+  array[] int gen_item_indices(int J) {
+    array[3*J] int hm_item_index;
 
     int base = 0;
     for(j in 1:(3*J)) {
@@ -25,8 +25,8 @@
     2 = resid
     3 = nu
    */ 
-  int[] gen_param_indices(int J) {
-    int hm_param_index[3*J];
+  array[] int gen_param_indices(int J) {
+    array[3*J] int hm_param_index;
 
     int base = 1;
     for(j in 1:(3*J)) {
@@ -49,8 +49,8 @@
     Instead of using (1:J); ((J+1) : (J*2)); ((J*2 + 1):(J*3)), one can just do:
     lamResNu_indices[1], lamResNu_indices[2], lamResNu_indices[3]
    */
-  int[,] gen_lamResNu_indices(int J) {
-    int lamResNu_indices[3, J];
+  array[,] int gen_lamResNu_indices(int J) {
+    array[3, J] int lamResNu_indices;
 
     for(p in 1:3) {
       for (j in 1:J) {

--- a/inst/stan/redifhm_all.stan
+++ b/inst/stan/redifhm_all.stan
@@ -11,7 +11,7 @@ data {
   int J; // Total number of indicators (Cols)
   int K; // Number of groups
 
-  int group[N]; // Group indicator array
+  array[N] int group; // Group indicator array
 
   matrix[N, J] x; // Indicator values
 
@@ -31,14 +31,14 @@ data {
 
 transformed data {
   int total = 3 * J; // Number of random measurement model effects (Not including latent mu/sd)
-  int hm_item_index[total] = gen_item_indices(J);
-  int hm_param_index[total] = gen_param_indices(J);
-  int lamResNu_indices[3, J] = gen_lamResNu_indices(J);
+  array[total] int hm_item_index = gen_item_indices(J);
+  array[total] int hm_param_index = gen_param_indices(J);
+  array[3, J] int lamResNu_indices = gen_lamResNu_indices(J);
   int save_scores = 1 - marginalize; // Inverse boolean for easy reading
   int hier_coding = 1 - sum_coding; // Inverse boolean for easy reading
   vector[N * J] x_vector;
-  row_vector[J] x_sorted[N];
-  int x_sorted_indices[K,2];
+  array[N] row_vector[J] x_sorted;
+  array[K,2] int x_sorted_indices;
 
   // Optimizations
   if(save_scores) { // Vectorize input data in col-major order. x_vector ~ N(to_vector(xhat), to_vector(shat)).
@@ -90,7 +90,7 @@ transformed parameters {
   row_vector[J] lambda = exp(lambda_log) + lambda_lowerbound;
   vector[N * save_scores] eta; // Declare
   matrix[K * marginalize, J * marginalize] multi_normal_mu;
-  matrix[J * marginalize, J * marginalize] multi_normal_sigma[K * marginalize];
+  array[K * marginalize] matrix[J * marginalize, J * marginalize] multi_normal_sigma;
 
   if(save_scores) { // Compute latent score.
     eta = eta_mean[group] + eta_z .* eta_sd[group];

--- a/inst/stan/unused/redif_hier.stan
+++ b/inst/stan/unused/redif_hier.stan
@@ -9,7 +9,7 @@ data {
   int J; // Total number of indicators
   int K; // Number of groups
 
-  int group[N]; // Group indicator array
+  array[N] int group; // Group indicator array
 
   matrix[N, J] x; // Indicator values
 
@@ -21,9 +21,9 @@ data {
 
 transformed data {
   int total = 3*J;
-  /* int hm_item_index[total] = gen_item_indices(J); */
-  /* int hm_param_index[total] = gen_param_indices(J); */
-  int lamResNu_indices[3, J] = gen_lamResNu_indices(J);
+  /* array[total] int hm_item_index = gen_item_indices(J); */
+  /* array[total] int hm_param_index = gen_param_indices(J); */
+  array[3, J] int lamResNu_indices = gen_lamResNu_indices(J);
   vector[N*J] x_vector = to_vector(x);
   real implied_ln_mu = 4 * hmre_mu;
   real implied_ln_scale = 2 * hmre_scale; // LN-scale = sqrt(4 * hmre_scale^2)

--- a/inst/stan/unused/redif_sum.stan
+++ b/inst/stan/unused/redif_sum.stan
@@ -10,7 +10,7 @@ data {
   int J; // Total number of indicators
   int K; // Number of groups
 
-  int group[N]; // Group indicator array
+  array[N] int group; // Group indicator array
 
   matrix[N, J] x; // Indicator values
 
@@ -22,9 +22,9 @@ data {
 
 transformed data {
   int total = 3*J;
-  /* int hm_item_index[total] = gen_item_indices(J); */
-  /* int hm_param_index[total] = gen_param_indices(J); */
-  int lamResNu_indices[3, J] = gen_lamResNu_indices(J);
+  /* array[total] int hm_item_index = gen_item_indices(J); */
+  /* array[total] int hm_param_index = gen_param_indices(J); */
+  array[3, J] int lamResNu_indices = gen_lamResNu_indices(J);
   vector[N*J] x_vector = to_vector(x);
   real implied_ln_mu = 4 * hmre_mu;
   real implied_ln_scale = 2 * hmre_scale; // LN-scale = sqrt(4 * hmre_scale^2)

--- a/inst/stan/unused/redifhm_hier.stan
+++ b/inst/stan/unused/redifhm_hier.stan
@@ -9,7 +9,7 @@ data {
   int J; // Total number of indicators
   int K; // Number of groups
 
-  int group[N]; // Group indicator array
+  array[N] int group; // Group indicator array
 
   matrix[N, J] x; // Indicator values
 
@@ -21,9 +21,9 @@ data {
 
 transformed data {
   int total = 3*J;
-  int hm_item_index[total] = gen_item_indices(J);
-  int hm_param_index[total] = gen_param_indices(J);
-  int lamResNu_indices[3, J] = gen_lamResNu_indices(J);
+  array[total] int hm_item_index = gen_item_indices(J);
+  array[total] int hm_param_index = gen_param_indices(J);
+  array[3, J] int lamResNu_indices = gen_lamResNu_indices(J);
   vector[N*J] x_vector = to_vector(x);
 }
 

--- a/inst/stan/unused/redifhm_hier_marg.stan
+++ b/inst/stan/unused/redifhm_hier_marg.stan
@@ -9,7 +9,7 @@ data {
   int J; // Total number of indicators
   int K; // Number of groups
 
-  int group[N]; // Group indicator array
+  array[N] int group; // Group indicator array
 
   matrix[N, J] x; // Indicator values
 
@@ -21,14 +21,14 @@ data {
 
 transformed data {
   int total = 3*J;
-  int hm_item_index[total] = gen_item_indices(J);
-  int hm_param_index[total] = gen_param_indices(J);
-  int lamResNu_indices[3, J] = gen_lamResNu_indices(J);
+  array[total] int hm_item_index = gen_item_indices(J);
+  array[total] int hm_param_index = gen_param_indices(J);
+  array[3, J] int lamResNu_indices = gen_lamResNu_indices(J);
   /* vector[N*J] x_vector = to_vector(x); */
   // Sort data
   /* matrix[N, J] x_sorted; */
-  row_vector[J] x_sorted[N];
-  int n_k[K] = rep_array(0, K);
+  array[N] row_vector[J] x_sorted;
+  array[K] int n_k = rep_array(0, K);
   for(n in 1:N) {
     n_k[group[n]] += 1;
   }
@@ -82,7 +82,7 @@ transformed parameters {
   row_vector[J] lambda = exp(lambda_log) + lambda_lowerbound;
   /* vector[N] eta = eta_mean[group] + eta_z .* eta_sd[group]; */
   matrix[K, J] multi_normal_mu = marg_expect_uni(lambda, nu, lambda_random, nu_random, eta_mean);
-  matrix[J, J] multi_normal_sigma[K] = marg_cov_uni(lambda, resid_log, lambda_random, resid_random, eta_sd);
+  array[K] matrix[J, J] multi_normal_sigma = marg_cov_uni(lambda, resid_log, lambda_random, resid_random, eta_sd);
 }
 
 model {

--- a/inst/stan/unused/redifhm_sum.stan
+++ b/inst/stan/unused/redifhm_sum.stan
@@ -10,7 +10,7 @@ data {
   int J; // Total number of indicators
   int K; // Number of groups
 
-  int group[N]; // Group indicator array
+  array[N] int group; // Group indicator array
 
   matrix[N, J] x; // Indicator values
 
@@ -22,9 +22,9 @@ data {
 
 transformed data {
   int total = 3*J;
-  int hm_item_index[total] = gen_item_indices(J);
-  int hm_param_index[total] = gen_param_indices(J);
-  int lamResNu_indices[3, J] = gen_lamResNu_indices(J);
+  array[total] int hm_item_index = gen_item_indices(J);
+  array[total] int hm_param_index = gen_param_indices(J);
+  array[3, J] int lamResNu_indices = gen_lamResNu_indices(J);
   vector[N*J] x_vector = to_vector(x);
 }
 


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
